### PR TITLE
errors: Add custom import for the package

### DIFF
--- a/errors/index.html
+++ b/errors/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="go-import" content="go.fraixed.es/errors git https://github.com/ifraixedes/go-errors">
+  <meta name="go-source" content="go.fraixed.es/errors https://github.com/ifraixedes/go-errors https://github.com/ifraixedes/go-errors/tree/master{/dir} https://github.com/ifraixedes/go-errors/blob/master{/dir}/{file}#L{line}">
+  <meta http-equiv="refresh" content="0; url=https://github.com/ifraixedes/go-errors">
+  <title>ifraixedes' errors package</title>
+</head>
+<body>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <p>Currently the following packages are available (import path => repository).</p>
   <ul>
     <li><b>go.fraixed.es/hmacval</b> => <a href="https://github.com/ifraixedes/go-hmac-validator">github.com/ifraixedes/go-hmac-validator</a></li>
+    <li><b>go.fraixed.es/errors</b> => <a href="https://github.com/ifraixedes/go-errors">github.com/ifraixedes/go-errors</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
Add the [errors package](https://github.com/ifraixedes/go-errors) custom import to the list and create the
directory for hosting the index with the HTML meta tags for indicating
the repository where the package's source is.