### PR TITLE
onepagestaticsite: Add custom import for the package

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,9 @@
   <h1>ifraixedes' Go packages</h1>
   <p>Currently the following packages are available (import path => repository).</p>
   <ul>
-    <li><b>go.fraixed.es/hmacval</b> => <a href="https://github.com/ifraixedes/go-hmac-validator">github.com/ifraixedes/go-hmac-validator</a></li>
     <li><b>go.fraixed.es/errors</b> => <a href="https://github.com/ifraixedes/go-errors">github.com/ifraixedes/go-errors</a></li>
+    <li><b>go.fraixed.es/hmacval</b> => <a href="https://github.com/ifraixedes/go-hmac-validator">github.com/ifraixedes/go-hmac-validator</a></li>
+    <li><b>go.fraixed.es/onepagestaticsite</b> => <a href="https://github.com/ifraixedes/one-page-static-site">github.com/ifraixedes/one-page-static-site</a></li>
   </ul>
 </body>
 </html>

--- a/onepagestaticsite/index.html
+++ b/onepagestaticsite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="go-import" content="go.fraixed.es/onepagestaticsite git https://github.com/ifraixedes/one-page-static-site">
+  <meta name="go-source" content="go.fraixed.es/onepagestaticsite https://github.com/ifraixedes/one-page-static-site https://github.com/ifraixedes/one-page-static-site/tree/master{/dir} https://github.com/ifraixedes/one-page-static-site/blob/master{/dir}/{file}#L{line}">
+  <meta http-equiv="refresh" content="0; url=https://github.com/ifraixedes/one-page-static-site">
+  <title>ifraixedes' onepagestaticsite package</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Add the [onepagestaticsite package](https://github.com/ifraixedes/one-page-static-site) custom import to the list and create
the directory for hosting the index with the HTML meta tags for
indicating the repository where the package's source is.