### PR TITLE
Add to the index relate Go sources & refactor the sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,25 +2,35 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>ifraixedes' Go packages</title>
+  <title>ifraixedes Go</title>
 </head>
 <body>
-  <h1>ifraixedes' Go packages</h1>
+  <h1>ifraixedes' Go sources</h1>
+  <p>This page contains references to some personal Go sources; there are packages, binaries an examples.</p>
+  <h2>Go packages</h2>
   <p>Currently the following libraries packages are available (import path => repository).</p>
   <ul>
-    <li><b>go.fraixed.es/errors</b> => <a href="https://github.com/ifraixedes/go-errors">github.com/ifraixedes/go-errors</a></li>
-    <li><b>go.fraixed.es/hmacval</b> => <a href="https://github.com/ifraixedes/go-hmac-validator">github.com/ifraixedes/go-hmac-validator</a></li>
+    <li><b>go.fraixed.es/errors</b> => <a href="https://github.com/ifraixedes/go-errors" target="_blank">github.com/ifraixedes/go-errors</a></li>
+    <li><b>go.fraixed.es/hmacval</b> => <a href="https://github.com/ifraixedes/go-hmac-validator" target="_blank">github.com/ifraixedes/go-hmac-validator</a></li>
   </ul>
-  <p>And the following binaries packages are available (install/import path => repository).</p>
+  <h2>Go binaries</h2>
+  <p>The following binaries packages are available (install/import path => repository).</p>
   <ul>
     <li>
       <dl>
         <dt>Binaries</dt>
-        <dd><b>go.fraixed.es/onepagestaticsite/cmd/opss</b> => <a href="https://github.com/ifraixedes/one-page-static-site/tree/master/cmd/opss">github.com/ifraixedes/one-page-static-site/cmd/opss</a></dd>
+        <dd><b>go.fraixed.es/onepagestaticsite/cmd/opss</b> => <a href="https://github.com/ifraixedes/one-page-static-site/tree/master/cmd/opss" target="_blank">github.com/ifraixedes/one-page-static-site/cmd/opss</a></dd>
         <dt>Public Packages</dt>
-        <dd><b>go.fraixed.es/onepagestaticsite</b> => <a href="https://github.com/ifraixedes/one-page-static-site">github.com/ifraixedes/one-page-static-site</a></dd>
+        <dd><b>go.fraixed.es/onepagestaticsite</b> => <a href="https://github.com/ifraixedes/one-page-static-site" target="_blank">github.com/ifraixedes/one-page-static-site</a></dd>
       </dl>
     </li>
+  </ul>
+  <h2>Go examples</h2>
+  <p>This section contain a list implementations which are examples of fictional requirements, proof of concepts, etc.</p>
+  <ul>
+    <li><b>Simple tool based in a fictional requirements which uses the Go CSV reader of the standard library</b>[<a href="https://github.com/ifraixedes/go-example-csv-reader" target="_blank">repo</a>]</li>
+    <li><b>Some personal interest in knowing a bit more of machine learning and involving Go in it</b> [<a href="https://github.com/ifraixedes/statistics-for-machine-learning-go" target="_blank">repo</a>]</li>
+    <li><b>A personal collection of Go runnable snippets for learning purpose</b> [<a href="https://github.com/ifraixedes/go-runnable-snippets" target="_blank">repo</a>]</li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
Add other Go sources links to the index.html despite which aren't
packages and reorganize the sections to make differentiation between
packages, binaries as before but also with these other Go sources.