### PR TITLE
storj/sntools: Add pkg to index & create redirections

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,10 @@
       <dl>
         <dt>Binaries</dt>
         <dd><b>go.fraixed.es/onepagestaticsite/cmd/opss</b> => <a href="https://github.com/ifraixedes/one-page-static-site/tree/master/cmd/opss" target="_blank">github.com/ifraixedes/one-page-static-site/cmd/opss</a></dd>
+        <dd><b>go.fraixed.es/storj/sntools/dbcleaner</b> => <a href="https://github.com/ifraixedes/storj-storagenode-tools/tree/master/dbcleaner" target="_blank">github.com/ifraixedes/storj-storagenode-tools/dbcleaner</a></dd>
         <dt>Public Packages</dt>
         <dd><b>go.fraixed.es/onepagestaticsite</b> => <a href="https://github.com/ifraixedes/one-page-static-site" target="_blank">github.com/ifraixedes/one-page-static-site</a></dd>
+        <dd><b>go.fraixed.es/storj/sntools</b> => <a href="https://github.com/ifraixedes/storj-storagenode-tools" target="_blank">github.com/ifraixedes/storj-storagenode-tools</a></dd>
       </dl>
     </li>
   </ul>

--- a/storj/sntools/dbcleaner/index.html
+++ b/storj/sntools/dbcleaner/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="go-import" content="go.fraixed.es/storj/sntools git https://github.com/ifraixedes/storj-storagenode-tools">
+  <meta name="go-source" content="go.fraixed.es/storj/sntools https://github.com/ifraixedes/storj-storagenode-tools https://github.com/ifraixedes/storj-storagenode-tools https://github.com/ifraixedes/storj-storagenode-tools/blob/master{/dir}/{file}#L{line}">
+  <meta http-equiv="refresh" content="0; url=https://github.com/ifraixedes/storj-storagenode-tools">
+  <title>ifraixedes' sntools/dbcleaner package</title>
+</head>
+<body>
+</body>
+</html>

--- a/storj/sntools/index.html
+++ b/storj/sntools/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="go-import" content="go.fraixed.es/storj/sntools git https://github.com/ifraixedes/storj-storagenode-tools">
+  <meta name="go-source" content="go.fraixed.es/storj/sntools https://github.com/ifraixedes/storj-storagenode-tools https://github.com/ifraixedes/storj-storagenode-tools https://github.com/ifraixedes/storj-storagenode-tools/blob/master{/dir}/{file}#L{line}">
+  <meta http-equiv="refresh" content="0; url=https://github.com/ifraixedes/storj-storagenode-tools">
+  <title>ifraixedes' sntools package</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Add the new binary package Storj Storage Node tools and reference to the
root package for any possible exported package and API.