### PR TITLE
storj/sntools/dbcleaner/orderlimit: Add package

### DIFF
--- a/storj/sntools/dbcleaner/orderlimit/index.html
+++ b/storj/sntools/dbcleaner/orderlimit/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="go-import" content="go.fraixed.es/storj/sntools git https://github.com/ifraixedes/storj-storagenode-tools">
+  <meta name="go-source" content="go.fraixed.es/storj/sntools https://github.com/ifraixedes/storj-storagenode-tools https://github.com/ifraixedes/storj-storagenode-tools https://github.com/ifraixedes/storj-storagenode-tools/blob/master{/dir}/{file}#L{line}">
+  <meta http-equiv="refresh" content="0; url=https://github.com/ifraixedes/storj-storagenode-tools">
+  <title>ifraixedes' sntools/dbcleaner/orderlimit package</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Add the forgotten storj/sntools/dbcleaner/orderlimit package for being
able to Go get it and show it in godoc.org.